### PR TITLE
Add cs_directory to config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ $ cat config.txt
 cs_host=127.0.0.1
 cs_port=12345
 cs_user=somedude
+cs_directory=/path/to/cobaltstrike/install
 ```
 ```
 RedShell> cs_load_config config.txt

--- a/redshell.py
+++ b/redshell.py
@@ -462,6 +462,10 @@ class RedShell(Cmd):
                     cs_port = re.search('cs_port=(.*)', line)
                     if cs_port:
                         self.cs_port = cs_port.group(1)
+                    
+                    cs_directory = re.search('cs_directory=(.*)', line)
+                    if cs_directory:
+                        self.cs_directory = cs_directory.group(1).strip(' ')
 
                     cs_user = re.search('cs_user=(.*)', line)
                     if cs_user:


### PR DESCRIPTION
Added the ability to include the cs_directory variable to the config file that can be loaded.

I have added the strip(' ') as if you have whitespace at the end of the line it will display correctly in the table but it will fail when it constructs the path to check for the agscript file. You could add a rstrip('/') to remove any trailing slashes but they don't intefere with the path when checking for the agscript file so didn't feel it was worth it. 